### PR TITLE
Add pagination for ImageListForDigest and implement FilterTags

### DIFF
--- a/pkg/extensions/search/gql_generated/generated.go
+++ b/pkg/extensions/search/gql_generated/generated.go
@@ -138,7 +138,7 @@ type ComplexityRoot struct {
 		Image                   func(childComplexity int, image string) int
 		ImageList               func(childComplexity int, repo string) int
 		ImageListForCve         func(childComplexity int, id string) int
-		ImageListForDigest      func(childComplexity int, id string) int
+		ImageListForDigest      func(childComplexity int, id string, requestedPage *PageInput) int
 		ImageListWithCVEFixed   func(childComplexity int, id string, image string) int
 		RepoListWithNewestImage func(childComplexity int, requestedPage *PageInput) int
 	}
@@ -167,7 +167,7 @@ type QueryResolver interface {
 	CVEListForImage(ctx context.Context, image string) (*CVEResultForImage, error)
 	ImageListForCve(ctx context.Context, id string) ([]*ImageSummary, error)
 	ImageListWithCVEFixed(ctx context.Context, id string, image string) ([]*ImageSummary, error)
-	ImageListForDigest(ctx context.Context, id string) ([]*ImageSummary, error)
+	ImageListForDigest(ctx context.Context, id string, requestedPage *PageInput) ([]*ImageSummary, error)
 	RepoListWithNewestImage(ctx context.Context, requestedPage *PageInput) ([]*RepoSummary, error)
 	ImageList(ctx context.Context, repo string) ([]*ImageSummary, error)
 	ExpandedRepoInfo(ctx context.Context, repo string) (*RepoInfo, error)
@@ -669,7 +669,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ImageListForDigest(childComplexity, args["id"].(string)), true
+		return e.complexity.Query.ImageListForDigest(childComplexity, args["id"].(string), args["requestedPage"].(*PageInput)), true
 
 	case "Query.ImageListWithCVEFixed":
 		if e.complexity.Query.ImageListWithCVEFixed == nil {
@@ -1035,7 +1035,7 @@ type Query {
     """
     Returns a list of images which contain the specified digest 
     """
-    ImageListForDigest(id: String!): [ImageSummary!]
+    ImageListForDigest(id: String!, requestedPage: PageInput): [ImageSummary!]
 
     """
     Returns a list of repos with the newest tag within
@@ -1200,6 +1200,15 @@ func (ec *executionContext) field_Query_ImageListForDigest_args(ctx context.Cont
 		}
 	}
 	args["id"] = arg0
+	var arg1 *PageInput
+	if tmp, ok := rawArgs["requestedPage"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requestedPage"))
+		arg1, err = ec.unmarshalOPageInput2ᚖzotregistryᚗioᚋzotᚋpkgᚋextensionsᚋsearchᚋgql_generatedᚐPageInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["requestedPage"] = arg1
 	return args, nil
 }
 
@@ -3920,7 +3929,7 @@ func (ec *executionContext) _Query_ImageListForDigest(ctx context.Context, field
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().ImageListForDigest(rctx, fc.Args["id"].(string))
+		return ec.resolvers.Query().ImageListForDigest(rctx, fc.Args["id"].(string), fc.Args["requestedPage"].(*PageInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/pkg/extensions/search/resolver.go
+++ b/pkg/extensions/search/resolver.go
@@ -6,6 +6,7 @@ package search
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -60,37 +61,78 @@ func GetResolverConfig(log log.Logger, storeController storage.StoreController,
 	}
 }
 
-func (r *queryResolver) getImageListForDigest(repoList []string, digest string) ([]*gql_generated.ImageSummary, error) {
-	imgResultForDigest := []*gql_generated.ImageSummary{}
-	olu := common.NewBaseOciLayoutUtils(r.storeController, r.log)
+func FilterByDigest(digest string) repodb.FilterFunc {
+	return func(repoMeta repodb.RepoMetadata, manifestMeta repodb.ManifestMetadata) bool {
+		lookupDigest := digest
+		contains := false
 
-	var errResult error
+		var manifest ispec.Manifest
 
-	for _, repo := range repoList {
-		r.log.Info().Str("repo", repo).Msg("filtering list of tags in image repo by digest")
-
-		imgTags, err := r.digestInfo.GetImageTagsByDigest(repo, digest)
+		err := json.Unmarshal(manifestMeta.ManifestBlob, &manifest)
 		if err != nil {
-			r.log.Error().Err(err).Msg("unable to get filtered list of image tags")
-
-			return []*gql_generated.ImageSummary{}, err
+			return false
 		}
 
-		for _, imageInfo := range imgTags {
-			imageConfig, err := olu.GetImageConfigInfo(repo, imageInfo.Digest)
-			if err != nil {
-				return []*gql_generated.ImageSummary{}, err
+		manifestDigest := godigest.FromBytes(manifestMeta.ManifestBlob).String()
+
+		// Check the image manifest in index.json matches the search digest
+		// This is a blob with mediaType application/vnd.oci.image.manifest.v1+json
+		if strings.Contains(manifestDigest, lookupDigest) {
+			contains = true
+		}
+
+		// Check the image config matches the search digest
+		// This is a blob with mediaType application/vnd.oci.image.config.v1+json
+		if strings.Contains(manifest.Config.Digest.String(), lookupDigest) {
+			contains = true
+		}
+
+		// Check to see if the individual layers in the oci image manifest match the digest
+		// These are blobs with mediaType application/vnd.oci.image.layer.v1.tar+gzip
+		for _, layer := range manifest.Layers {
+			if strings.Contains(layer.Digest.String(), lookupDigest) {
+				contains = true
 			}
-
-			isSigned := olu.CheckManifestSignature(repo, imageInfo.Digest)
-			imageInfo := convert.BuildImageInfo(repo, imageInfo.Tag, imageInfo.Digest,
-				imageInfo.Manifest, imageConfig, isSigned)
-
-			imgResultForDigest = append(imgResultForDigest, imageInfo)
 		}
+
+		return contains
+	}
+}
+
+func getImageListForDigest(ctx context.Context, digest string, repoDB repodb.RepoDB, cveInfo cveinfo.CveInfo,
+	requestedPage *gql_generated.PageInput,
+) ([]*gql_generated.ImageSummary, error) {
+	imageList := make([]*gql_generated.ImageSummary, 0)
+
+	if requestedPage == nil {
+		requestedPage = &gql_generated.PageInput{}
 	}
 
-	return imgResultForDigest, errResult
+	skip := convert.SkipQGLField{
+		Vulnerabilities: canSkipField(convert.GetPreloads(ctx), "Images.Vulnerabilities"),
+	}
+
+	pageInput := repodb.PageInput{
+		Limit:  safeDerefferencing(requestedPage.Limit, 0),
+		Offset: safeDerefferencing(requestedPage.Offset, 0),
+		SortBy: repodb.SortCriteria(
+			safeDerefferencing(requestedPage.SortBy, gql_generated.SortCriteriaRelevance),
+		),
+	}
+
+	// get all repos
+	reposMeta, manifestMetaMap, err := repoDB.FilterTags(ctx, FilterByDigest(digest), pageInput)
+	if err != nil {
+		return []*gql_generated.ImageSummary{}, err
+	}
+
+	for _, repoMeta := range reposMeta {
+		imageSummaries := convert.RepoMeta2ImageSummaries(ctx, repoMeta, manifestMetaMap, skip, cveInfo)
+
+		imageList = append(imageList, imageSummaries...)
+	}
+
+	return imageList, nil
 }
 
 func getImageSummary(ctx context.Context, repo, tag string, repoDB repodb.RepoDB,

--- a/pkg/extensions/search/schema.graphql
+++ b/pkg/extensions/search/schema.graphql
@@ -192,7 +192,7 @@ type Query {
     """
     Returns a list of images which contain the specified digest 
     """
-    ImageListForDigest(id: String!): [ImageSummary!]
+    ImageListForDigest(id: String!, requestedPage: PageInput): [ImageSummary!]
 
     """
     Returns a list of repos with the newest tag within

--- a/pkg/extensions/search/schema.resolvers.go
+++ b/pkg/extensions/search/schema.resolvers.go
@@ -144,51 +144,12 @@ func (r *queryResolver) ImageListWithCVEFixed(ctx context.Context, id string, im
 }
 
 // ImageListForDigest is the resolver for the ImageListForDigest field.
-func (r *queryResolver) ImageListForDigest(ctx context.Context, id string) ([]*gql_generated.ImageSummary, error) {
-	imgResultForDigest := []*gql_generated.ImageSummary{}
-
+func (r *queryResolver) ImageListForDigest(ctx context.Context, id string, requestedPage *gql_generated.PageInput) ([]*gql_generated.ImageSummary, error) {
 	r.log.Info().Msg("extracting repositories")
 
-	defaultStore := r.storeController.DefaultStore
+	imgResultForDigest, err := getImageListForDigest(ctx, id, r.repoDB, r.cveInfo, requestedPage)
 
-	repoList, err := defaultStore.GetRepositories()
-	if err != nil {
-		r.log.Error().Err(err).Msg("unable to search repositories")
-
-		return imgResultForDigest, err
-	}
-
-	r.log.Info().Msg("scanning each global repository")
-
-	partialImgResultForDigest, err := r.getImageListForDigest(repoList, id)
-	if err != nil {
-		r.log.Error().Err(err).Msg("unable to get image and tag list for global repositories")
-
-		return imgResultForDigest, err
-	}
-
-	imgResultForDigest = append(imgResultForDigest, partialImgResultForDigest...)
-
-	subStore := r.storeController.SubStore
-	for _, store := range subStore {
-		subRepoList, err := store.GetRepositories()
-		if err != nil {
-			r.log.Error().Err(err).Msg("unable to search sub-repositories")
-
-			return imgResultForDigest, err
-		}
-
-		partialImgResultForDigest, err = r.getImageListForDigest(subRepoList, id)
-		if err != nil {
-			r.log.Error().Err(err).Msg("unable to get image and tag list for sub-repositories")
-
-			return imgResultForDigest, err
-		}
-
-		imgResultForDigest = append(imgResultForDigest, partialImgResultForDigest...)
-	}
-
-	return imgResultForDigest, nil
+	return imgResultForDigest, err
 }
 
 // RepoListWithNewestImage is the resolver for the RepoListWithNewestImage field.

--- a/pkg/storage/repodb/boltdb_wrapper.go
+++ b/pkg/storage/repodb/boltdb_wrapper.go
@@ -722,13 +722,112 @@ func ScoreRepoName(searchText string, repoName string) int {
 	return -1
 }
 
+func (bdw BoltDBWrapper) FilterTags(ctx context.Context, filter FilterFunc,
+	requestedPage PageInput,
+) ([]RepoMetadata, map[string]ManifestMetadata, error) {
+	var (
+		foundRepos               = make([]RepoMetadata, 0)
+		foundManifestMetadataMap = make(map[string]ManifestMetadata)
+		pageFinder               *ImagePageFinder
+	)
+
+	pageFinder, err := NewBaseImagePageFinder(requestedPage.Limit, requestedPage.Offset, requestedPage.SortBy)
+	if err != nil {
+		return []RepoMetadata{}, map[string]ManifestMetadata{}, err
+	}
+
+	err = bdw.db.View(func(tx *bolt.Tx) error {
+		var (
+			manifestMetadataMap = make(map[string]ManifestMetadata)
+			repoBuck            = tx.Bucket([]byte(RepoMetadataBucket))
+			manifestBuck        = tx.Bucket([]byte(ManifestMetadataBucket))
+			cursor              = repoBuck.Cursor()
+		)
+
+		repoName, repoMetaBlob := cursor.First()
+
+		for ; repoName != nil; repoName, repoMetaBlob = cursor.Next() {
+			if ok, err := repoIsUserAvailable(ctx, string(repoName)); !ok || err != nil {
+				continue
+			}
+
+			repoMeta := RepoMetadata{}
+
+			err := json.Unmarshal(repoMetaBlob, &repoMeta)
+			if err != nil {
+				return err
+			}
+
+			matchedTags := make(map[string]string)
+			// take all manifestMetas
+			for tag, manifestDigest := range repoMeta.Tags {
+				matchedTags[tag] = manifestDigest
+
+				// in case tags reference the same manifest we don't download from DB multiple times
+				if manifestMeta, manifestExists := manifestMetadataMap[manifestDigest]; manifestExists {
+					manifestMetadataMap[manifestDigest] = manifestMeta
+
+					continue
+				}
+
+				manifestMetaBlob := manifestBuck.Get([]byte(manifestDigest))
+				if manifestMetaBlob == nil {
+					return zerr.ErrManifestMetaNotFound
+				}
+
+				var manifestMeta ManifestMetadata
+
+				err := json.Unmarshal(manifestMetaBlob, &manifestMeta)
+				if err != nil {
+					return errors.Wrapf(err, "repodb: error while unmashaling manifest metadata for digest %s", manifestDigest)
+				}
+
+				var configContent ispec.Image
+
+				err = json.Unmarshal(manifestMeta.ConfigBlob, &configContent)
+				if err != nil {
+					return errors.Wrapf(err, "repodb: error while unmashaling manifest metadata for digest %s", manifestDigest)
+				}
+
+				if !filter(repoMeta, manifestMeta) {
+					delete(matchedTags, tag)
+					delete(manifestMetadataMap, manifestDigest)
+
+					continue
+				}
+
+				manifestMetadataMap[manifestDigest] = manifestMeta
+			}
+
+			repoMeta.Tags = matchedTags
+
+			pageFinder.Add(DetailedRepoMeta{
+				RepoMeta: repoMeta,
+			})
+		}
+
+		foundRepos = pageFinder.Page()
+
+		// keep just the manifestMeta we need
+		for _, repoMeta := range foundRepos {
+			for _, manifestDigest := range repoMeta.Tags {
+				foundManifestMetadataMap[manifestDigest] = manifestMetadataMap[manifestDigest]
+			}
+		}
+
+		return nil
+	})
+
+	return foundRepos, foundManifestMetadataMap, err
+}
+
 func (bdw BoltDBWrapper) SearchTags(ctx context.Context, searchText string, filter Filter, requestedPage PageInput,
 ) ([]RepoMetadata, map[string]ManifestMetadata, error) {
 	var (
 		foundRepos               = make([]RepoMetadata, 0)
 		foundManifestMetadataMap = make(map[string]ManifestMetadata)
 
-		pageFinder PageFinder
+		pageFinder *ImagePageFinder
 	)
 
 	pageFinder, err := NewBaseImagePageFinder(requestedPage.Limit, requestedPage.Offset, requestedPage.SortBy)
@@ -814,6 +913,10 @@ func (bdw BoltDBWrapper) SearchTags(ctx context.Context, searchText string, filt
 					}
 
 					manifestMetadataMap[manifestDigest] = manifestMeta
+				}
+
+				if len(matchedTags) == 0 {
+					continue
 				}
 
 				repoMeta.Tags = matchedTags

--- a/pkg/storage/repodb/pagination.go
+++ b/pkg/storage/repodb/pagination.go
@@ -153,6 +153,17 @@ func (bpt *ImagePageFinder) Page() []RepoMetadata {
 	remainingOffset := bpt.offset
 	remainingLimit := bpt.limit
 
+	repos := make([]RepoMetadata, 0)
+
+	if remainingOffset == 0 && remainingLimit == 0 {
+		for _, drm := range bpt.pageBuffer {
+			repo := drm.RepoMeta
+			repos = append(repos, repo)
+		}
+
+		return repos
+	}
+
 	// bring cursor to position in RepoMeta array
 	for _, drm := range bpt.pageBuffer {
 		if remainingOffset < len(drm.RepoMeta.Tags) {
@@ -169,8 +180,6 @@ func (bpt *ImagePageFinder) Page() []RepoMetadata {
 	if repoStartIndex >= len(bpt.pageBuffer) {
 		return []RepoMetadata{}
 	}
-
-	repos := make([]RepoMetadata, 0)
 
 	// finish counting remaining tags inside the first repo meta
 	partialTags := map[string]string{}

--- a/pkg/storage/repodb/repodb.go
+++ b/pkg/storage/repodb/repodb.go
@@ -13,6 +13,8 @@ const (
 	RepoMetadataBucket     = "RepoMetadata"
 )
 
+type FilterFunc func(repoMeta RepoMetadata, manifestMeta ManifestMetadata) bool
+
 type RepoDB interface { //nolint:interfacebloat
 	// SetRepoDescription sets the repo description
 	SetRepoDescription(repo, description string) error
@@ -65,6 +67,10 @@ type RepoDB interface { //nolint:interfacebloat
 	// SearchTags searches for images(repo:tag) given a search string
 	SearchTags(ctx context.Context, searchText string, filter Filter, requestedPage PageInput) (
 		[]RepoMetadata, map[string]ManifestMetadata, error)
+
+	// FilterTags filters for images given a filter function
+	FilterTags(ctx context.Context, filter FilterFunc,
+		requestedPage PageInput) ([]RepoMetadata, map[string]ManifestMetadata, error)
 
 	// SearchDigests searches for digests given a search string
 	SearchDigests(ctx context.Context, searchText string, requestedPage PageInput) (

--- a/pkg/test/mocks/search_db_mock.go
+++ b/pkg/test/mocks/search_db_mock.go
@@ -44,6 +44,10 @@ type RepoDBMock struct {
 	SearchTagsFn func(ctx context.Context, searchText string, filter repodb.Filter, requestedPage repodb.PageInput) (
 		[]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error)
 
+	FilterTagsFn func(ctx context.Context, filter repodb.FilterFunc,
+		requestedPage repodb.PageInput,
+	) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error)
+
 	SearchDigestsFn func(ctx context.Context, searchText string, requestedPage repodb.PageInput) (
 		[]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error)
 
@@ -186,6 +190,16 @@ func (sdm RepoDBMock) SearchTags(ctx context.Context, searchText string, filter 
 ) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
 	if sdm.SearchTagsFn != nil {
 		return sdm.SearchTagsFn(ctx, searchText, filter, requestedPage)
+	}
+
+	return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, nil
+}
+
+func (sdm RepoDBMock) FilterTags(ctx context.Context, filter repodb.FilterFunc,
+	requestedPage repodb.PageInput,
+) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+	if sdm.FilterTagsFn != nil {
+		return sdm.FilterTagsFn(ctx, filter, requestedPage)
 	}
 
 	return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, nil


### PR DESCRIPTION
ImageListForDigest can now return paginated results, directly from DB. It uses FilterTags, a new method to filter tags (obviously) based on the criteria provided in the filter function.
Pagination of tags is now slightly different, it shows all results if no limit and offset are provided.

Signed-off-by: Alex Stan <alexandrustan96@yahoo.ro>