### PR TITLE
feat(repodb): DerivedImageList and BaseImageList make use of RepoDB

### DIFF
--- a/pkg/cli/image_cmd_test.go
+++ b/pkg/cli/image_cmd_test.go
@@ -416,7 +416,7 @@ func TestDerivedImageList(t *testing.T) {
 		_ = controller.Server.Shutdown(ctx)
 	}(ctlr)
 
-	err := uploadManifest(url)
+	err := uploadManifestDerivedBase(url)
 	if err != nil {
 		panic(err)
 	}
@@ -426,7 +426,7 @@ func TestDerivedImageList(t *testing.T) {
 	Convey("Test from real server", t, func() {
 		Convey("Test derived images list working", func() {
 			t.Logf("%s", ctlr.Config.Storage.RootDirectory)
-			args := []string{"imagetest", "--derived-images", "repo7:test:1.0"}
+			args := []string{"imagetest", "--derived-images", "repo7:test:2.0"}
 			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 			defer os.Remove(configPath)
 			cmd := NewImageCommand(new(searchService))
@@ -440,33 +440,12 @@ func TestDerivedImageList(t *testing.T) {
 			str := space.ReplaceAllString(buff.String(), " ")
 			actual := strings.TrimSpace(str)
 			So(actual, ShouldContainSubstring, "IMAGE NAME TAG DIGEST SIGNED SIZE")
-			So(actual, ShouldContainSubstring, "repo7 test:2.0 883fc0c5 false 492B")
-		})
-
-		Convey("Test derived images fail", func() {
-			t.Logf("%s", ctlr.Config.Storage.RootDirectory)
-			err = os.Chmod(ctlr.Config.Storage.RootDirectory, 0o000)
-			So(err, ShouldBeNil)
-
-			defer func() {
-				err := os.Chmod(ctlr.Config.Storage.RootDirectory, 0o755)
-				So(err, ShouldBeNil)
-			}()
-			args := []string{"imagetest", "--derived-images", "repo7:test:1.0"}
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-			defer os.Remove(configPath)
-			cmd := NewImageCommand(new(searchService))
-			buff := &bytes.Buffer{}
-			cmd.SetOut(buff)
-			cmd.SetErr(buff)
-			cmd.SetArgs(args)
-			err = cmd.Execute()
-			So(err, ShouldNotBeNil)
+			So(actual, ShouldContainSubstring, "repo7 test:1.0 2694fdb0 false 824B")
 		})
 
 		Convey("Test derived images list cannot print", func() {
 			t.Logf("%s", ctlr.Config.Storage.RootDirectory)
-			args := []string{"imagetest", "--derived-images", "repo7:test:1.0", "-o", "random"}
+			args := []string{"imagetest", "--derived-images", "repo7:test:2.0", "-o", "random"}
 			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 			defer os.Remove(configPath)
 			cmd := NewImageCommand(new(searchService))
@@ -515,7 +494,7 @@ func TestBaseImageList(t *testing.T) {
 		_ = controller.Server.Shutdown(ctx)
 	}(ctlr)
 
-	err := uploadManifest(url)
+	err := uploadManifestDerivedBase(url)
 	if err != nil {
 		panic(err)
 	}
@@ -539,28 +518,7 @@ func TestBaseImageList(t *testing.T) {
 			str := space.ReplaceAllString(buff.String(), " ")
 			actual := strings.TrimSpace(str)
 			So(actual, ShouldContainSubstring, "IMAGE NAME TAG DIGEST SIGNED SIZE")
-			So(actual, ShouldContainSubstring, "repo7 test:2.0 883fc0c5 false 492B")
-		})
-
-		Convey("Test base images fail", func() {
-			t.Logf("%s", ctlr.Config.Storage.RootDirectory)
-			err = os.Chmod(ctlr.Config.Storage.RootDirectory, 0o000)
-			So(err, ShouldBeNil)
-
-			defer func() {
-				err := os.Chmod(ctlr.Config.Storage.RootDirectory, 0o755)
-				So(err, ShouldBeNil)
-			}()
-			args := []string{"imagetest", "--base-images", "repo7:test:1.0"}
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-			defer os.Remove(configPath)
-			cmd := NewImageCommand(new(searchService))
-			buff := &bytes.Buffer{}
-			cmd.SetOut(buff)
-			cmd.SetErr(buff)
-			cmd.SetArgs(args)
-			err = cmd.Execute()
-			So(err, ShouldNotBeNil)
+			So(actual, ShouldContainSubstring, "repo7 test:2.0 3fc80493 false 494B")
 		})
 
 		Convey("Test base images list cannot print", func() {
@@ -1469,6 +1427,98 @@ func uploadManifest(url string) error {
 	return nil
 }
 
+func uploadManifestDerivedBase(url string) error {
+	// create a blob/layer
+	_, _ = resty.R().Post(url + "/v2/repo7/blobs/uploads/")
+
+	content1 := []byte("this is a blob5.0")
+	content2 := []byte("this is a blob5.1")
+	content3 := []byte("this is a blob5.2")
+	digest1 := godigest.FromBytes(content1)
+	digest2 := godigest.FromBytes(content2)
+	digest3 := godigest.FromBytes(content3)
+	_, _ = resty.R().SetQueryParam("digest", digest1.String()).
+		SetHeader("Content-Type", "application/octet-stream").SetBody(content1).Post(url + "/v2/repo7/blobs/uploads/")
+	_, _ = resty.R().SetQueryParam("digest", digest2.String()).
+		SetHeader("Content-Type", "application/octet-stream").SetBody(content2).Post(url + "/v2/repo7/blobs/uploads/")
+	_, _ = resty.R().SetQueryParam("digest", digest3.String()).
+		SetHeader("Content-Type", "application/octet-stream").SetBody(content3).Post(url + "/v2/repo7/blobs/uploads/")
+
+	// upload image config blob
+	resp, _ := resty.R().Post(url + "/v2/repo7/blobs/uploads/")
+	loc := test.Location(url, resp)
+	cblob, cdigest := test.GetImageConfig()
+
+	_, _ = resty.R().
+		SetContentLength(true).
+		SetHeader("Content-Length", fmt.Sprintf("%d", len(cblob))).
+		SetHeader("Content-Type", "application/octet-stream").
+		SetQueryParam("digest", cdigest.String()).
+		SetBody(cblob).
+		Put(loc)
+
+	// create a manifest
+	manifest := ispec.Manifest{
+		Config: ispec.Descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    cdigest,
+			Size:      int64(len(cblob)),
+		},
+		Layers: []ispec.Descriptor{
+			{
+				MediaType: "application/vnd.oci.image.layer.v1.tar",
+				Digest:    digest1,
+				Size:      int64(len(content1)),
+			}, {
+				MediaType: "application/vnd.oci.image.layer.v1.tar",
+				Digest:    digest2,
+				Size:      int64(len(content2)),
+			}, {
+				MediaType: "application/vnd.oci.image.layer.v1.tar",
+				Digest:    digest3,
+				Size:      int64(len(content3)),
+			},
+		},
+	}
+	manifest.SchemaVersion = 2
+
+	content, err := json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+
+	_, _ = resty.R().SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
+		SetBody(content).Put(url + "/v2/repo7/manifests/test:1.0")
+
+	content1 = []byte("this is a blob5.0")
+	digest1 = godigest.FromBytes(content1)
+	// create a manifest with one common layer blob
+	manifest = ispec.Manifest{
+		Config: ispec.Descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    cdigest,
+			Size:      int64(len(cblob)),
+		},
+		Layers: []ispec.Descriptor{
+			{
+				MediaType: "application/vnd.oci.image.layer.v1.tar",
+				Digest:    digest1,
+				Size:      int64(len(content1)),
+			},
+		},
+	}
+	manifest.SchemaVersion = 2
+
+	content, err = json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+	_, _ = resty.R().SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
+		SetBody(content).Put(url + "/v2/repo7/manifests/test:2.0")
+
+	return nil
+}
+
 type mockService struct{}
 
 func (service mockService) getRepos(ctx context.Context, config searchConfig, username,
@@ -1489,7 +1539,7 @@ func (service mockService) getDerivedImageListGQL(ctx context.Context, config se
 	derivedImage string,
 ) (*imageListStructForDerivedImagesGQL, error) {
 	imageListGQLResponse := &imageListStructForDerivedImagesGQL{}
-	imageListGQLResponse.Data.ImageList = []imageStruct{
+	imageListGQLResponse.Data.ImageList.Results = []imageStruct{
 		{
 			RepoName:     "dummyImageName",
 			Tag:          "tag",
@@ -1507,7 +1557,7 @@ func (service mockService) getBaseImageListGQL(ctx context.Context, config searc
 	derivedImage string,
 ) (*imageListStructForBaseImagesGQL, error) {
 	imageListGQLResponse := &imageListStructForBaseImagesGQL{}
-	imageListGQLResponse.Data.ImageList = []imageStruct{
+	imageListGQLResponse.Data.ImageList.Results = []imageStruct{
 		{
 			RepoName:     "dummyImageName",
 			Tag:          "tag",

--- a/pkg/cli/searcher.go
+++ b/pkg/cli/searcher.go
@@ -241,7 +241,7 @@ func (search derivedImageListSearcherGQL) search(config searchConfig) (bool, err
 		return true, err
 	}
 
-	if err := printResult(config, imageList.Data.ImageList); err != nil {
+	if err := printResult(config, imageList.Data.ImageList.Results); err != nil {
 		return true, err
 	}
 
@@ -266,7 +266,7 @@ func (search baseImageListSearcherGQL) search(config searchConfig) (bool, error)
 		return true, err
 	}
 
-	if err := printResult(config, imageList.Data.ImageList); err != nil {
+	if err := printResult(config, imageList.Data.ImageList.Results); err != nil {
 		return true, err
 	}
 

--- a/pkg/cli/service.go
+++ b/pkg/cli/service.go
@@ -71,14 +71,16 @@ func (service searchService) getDerivedImageListGQL(ctx context.Context, config 
 	query := fmt.Sprintf(`
 		{
 			DerivedImageList(image:"%s"){
-				RepoName,
-				Tag,
-				Digest,
-				ConfigDigest,
-				Layers {Size Digest},
-				LastUpdated,
-				IsSigned,
-				Size
+				Results{
+					RepoName,
+					Tag,
+					Digest,
+					ConfigDigest,
+					Layers {Size Digest},
+					LastUpdated,
+					IsSigned,
+					Size
+				}
 			}
 		}`, derivedImage)
 
@@ -98,14 +100,16 @@ func (service searchService) getBaseImageListGQL(ctx context.Context, config sea
 	query := fmt.Sprintf(`
 		{
 			BaseImageList(image:"%s"){
-				RepoName,
-				Tag,
-				Digest,
-				ConfigDigest,
-				Layers {Size Digest},
-				LastUpdated,
-				IsSigned,
-				Size
+				Results{
+					RepoName,
+					Tag,
+					Digest,
+					ConfigDigest,
+					Layers {Size Digest},
+					LastUpdated,
+					IsSigned,
+					Size
+				}
 			}
 		}`, baseImage)
 
@@ -862,6 +866,13 @@ type imageStruct struct {
 	IsSigned     bool `json:"isSigned"`
 }
 
+type DerivedImageList struct {
+	Results []imageStruct `json:"results"`
+}
+type BaseImageList struct {
+	Results []imageStruct `json:"results"`
+}
+
 type imageListStructGQL struct {
 	Errors []errorGraphQL `json:"errors"`
 	Data   struct {
@@ -879,14 +890,14 @@ type imageListStructForDigestGQL struct {
 type imageListStructForDerivedImagesGQL struct {
 	Errors []errorGraphQL `json:"errors"`
 	Data   struct {
-		ImageList []imageStruct `json:"DerivedImageList"` //nolint:tagliatelle
+		ImageList DerivedImageList `json:"DerivedImageList"` //nolint:tagliatelle
 	} `json:"data"`
 }
 
 type imageListStructForBaseImagesGQL struct {
 	Errors []errorGraphQL `json:"errors"`
 	Data   struct {
-		ImageList []imageStruct `json:"BaseImageList"` //nolint:tagliatelle
+		ImageList BaseImageList `json:"BaseImageList"` //nolint:tagliatelle
 	} `json:"data"`
 }
 

--- a/pkg/extensions/search/common/common_test.go
+++ b/pkg/extensions/search/common/common_test.go
@@ -64,6 +64,15 @@ type RepoWithNewestImageResponse struct {
 	Errors                  []ErrorGQL              `json:"errors"`
 }
 
+type BaseImageListResponse struct {
+	BaseImageList BaseImageList `json:"data"`
+	Errors        []ErrorGQL    `json:"errors"`
+}
+type DerivedImageListResponse struct {
+	DerivedImageList DerivedImageList `json:"data"`
+	Errors           []ErrorGQL       `json:"errors"`
+}
+
 type ImageListResponse struct {
 	ImageList ImageList  `json:"data"`
 	Errors    []ErrorGQL `json:"errors"`
@@ -103,9 +112,22 @@ type PaginatedReposResult struct {
 	Page    repodb.PageInfo      `json:"page"`
 }
 
+type PaginatedImagesResult struct {
+	Results []common.ImageSummary `json:"results"`
+	Page    repodb.PageInfo       `json:"page"`
+}
+
 //nolint:tagliatelle // graphQL schema
 type RepoListWithNewestImage struct {
 	PaginatedReposResult `json:"RepoListWithNewestImage"`
+}
+
+type BaseImageList struct {
+	PaginatedImagesResult `json:"baseImageList"`
+}
+
+type DerivedImageList struct {
+	PaginatedImagesResult `json:"derivedImageList"`
 }
 
 type ErrorGQL struct {
@@ -1304,6 +1326,7 @@ func TestDerivedImageList(t *testing.T) {
 			{10, 10, 10, 10},
 			{10, 10, 10, 11},
 			{11, 11, 10, 10},
+			{11, 10, 10, 10},
 		}
 
 		manifest = ispec.Manifest{
@@ -1358,67 +1381,114 @@ func TestDerivedImageList(t *testing.T) {
 		)
 		So(err, ShouldBeNil)
 
-		query := `
-			{
-				DerivedImageList(image:"test-repo"){
-					RepoName,
-					Tag,
-					Digest,
-					ConfigDigest,
-					LastUpdated,
-					IsSigned,
-					Size
-				}
-			}`
+		manifest = ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[2]),
+					Size:      int64(len(layers[2])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[3]),
+					Size:      int64(len(layers[3])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[4]),
+					Size:      int64(len(layers[4])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[5]),
+					Size:      int64(len(layers[5])),
+				},
+			},
+		}
 
-		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
-		So(resp, ShouldNotBeNil)
-		So(strings.Contains(string(resp.Body()), "same-layers"), ShouldBeTrue) //nolint:goconst
-		So(strings.Contains(string(resp.Body()), "missing-layers"), ShouldBeFalse)
-		So(strings.Contains(string(resp.Body()), "more-layers"), ShouldBeTrue)
+		repoName = "all-layers"
+
+		err = UploadImage(
+			Image{
+				Manifest: manifest,
+				Config:   config,
+				Layers:   layers,
+				Tag:      "latest",
+			},
+			baseURL,
+			repoName,
+		)
 		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, 200)
-	})
 
-	Convey("Inexistent repository", t, func() {
-		query := `
-			{
-				DerivedImageList(image:"inexistent-image"){
-					RepoName,
-					Tag,
-					Digest,
-					ConfigDigest,
-					LastUpdated,
-					IsSigned,
-					Size
-				}
-			}`
+		Convey("non paginated query", func() {
+			query := `
+				{
+					DerivedImageList(image:"test-repo:latest"){
+						Results{
+							RepoName,
+							Tag,
+							Digest,
+							ConfigDigest,
+							LastUpdated,
+							IsSigned,
+							Size
+						}
+					}
+				}`
 
-		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
-		So(strings.Contains(string(resp.Body()), "repository: not found"), ShouldBeTrue)
-		So(err, ShouldBeNil)
-	})
+			resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
+			So(resp, ShouldNotBeNil)
+			So(strings.Contains(string(resp.Body()), "same-layers"), ShouldBeFalse) //nolint:goconst
+			So(strings.Contains(string(resp.Body()), "missing-layers"), ShouldBeFalse)
+			So(strings.Contains(string(resp.Body()), "more-layers"), ShouldBeTrue)
+			So(strings.Contains(string(resp.Body()), "all-layers"), ShouldBeTrue)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, 200)
+		})
 
-	Convey("Failed to get manifest", t, func() {
-		err := os.Mkdir(path.Join(rootDir, "fail-image"), 0o000)
-		So(err, ShouldBeNil)
+		Convey("paginated query", func() {
+			query := `
+				{
+					DerivedImageList(image:"test-repo:latest", requestedPage:{limit: 1, offset: 0, sortBy:ALPHABETIC_ASC}){
+						Results{
+							RepoName,
+							Tag,
+							Digest,
+							ConfigDigest,
+							LastUpdated,
+							IsSigned,
+							Size
+						}
+					}
+				}`
 
-		query := `
-			{
-				DerivedImageList(image:"fail-image"){
-					RepoName,
-					Tag,
-					Digest,
-					ConfigDigest,
-					LastUpdated,
-					IsSigned,
-					Size
-				}
-			}`
-
-		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
-		So(strings.Contains(string(resp.Body()), "permission denied"), ShouldBeTrue)
-		So(err, ShouldBeNil)
+			resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
+			So(resp, ShouldNotBeNil)
+			So(strings.Contains(string(resp.Body()), "same-layers"), ShouldBeFalse) //nolint:goconst
+			So(strings.Contains(string(resp.Body()), "missing-layers"), ShouldBeFalse)
+			So(strings.Contains(string(resp.Body()), "more-layers"), ShouldBeFalse)
+			So(strings.Contains(string(resp.Body()), "all-layers"), ShouldBeTrue)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, 200)
+		})
 	})
 }
 
@@ -1447,18 +1517,24 @@ func TestDerivedImageListNoRepos(t *testing.T) {
 		query := `
 			{
 				DerivedImageList(image:"test-image"){
-					RepoName,
-					Tag,
-					Digest,
-					ConfigDigest,
-					LastUpdated,
-					IsSigned,
-					Size
+					Results{
+						RepoName,
+						Tag,
+						Digest,
+						ConfigDigest,
+						LastUpdated,
+						IsSigned,
+						Size
+					}
 				}
 			}`
 
 		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
-		So(strings.Contains(string(resp.Body()), "{\"data\":{\"DerivedImageList\":[]}}"), ShouldBeTrue)
+		So(resp, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+
+		So(strings.Contains(string(resp.Body()), "{\"data\":{\"DerivedImageList\":{\"Results\":[]}}}"), ShouldBeTrue)
 		So(err, ShouldBeNil)
 	})
 }
@@ -1705,6 +1781,43 @@ func TestBaseImageList(t *testing.T) {
 		)
 		So(err, ShouldBeNil)
 
+		// create image with one layer, which is also present in the given image
+		layers = [][]byte{
+			{10, 11, 10, 11},
+		}
+
+		manifest = ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+			},
+		}
+
+		repoName = "one-layer"
+
+		err = UploadImage(
+			Image{
+				Manifest: manifest,
+				Config:   config,
+				Layers:   layers,
+				Tag:      "latest",
+			},
+			baseURL,
+			repoName,
+		)
+		So(err, ShouldBeNil)
+
 		// create image with less layers than the given image, but one layer isn't in the given image
 		layers = [][]byte{
 			{10, 11, 10, 11},
@@ -1852,70 +1965,63 @@ func TestBaseImageList(t *testing.T) {
 		)
 		So(err, ShouldBeNil)
 
-		query := `
-			{
-				BaseImageList(image:"test-repo"){
-					RepoName,
-					Tag,
-					Digest,
-					ConfigDigest,
-					LastUpdated,
-					IsSigned,
-					Size
-				}
-			}`
+		Convey("non paginated query", func() {
+			query := `
+				{
+					BaseImageList(image:"test-repo:latest"){
+						Results{
+							RepoName,
+							Tag,
+							Digest,
+							ConfigDigest,
+							LastUpdated,
+							IsSigned,
+							Size
+						}
+					}
+				}`
 
-		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
-		So(resp, ShouldNotBeNil)
-		So(strings.Contains(string(resp.Body()), "same-layers"), ShouldBeTrue) //nolint:goconst
-		So(strings.Contains(string(resp.Body()), "less-layers"), ShouldBeTrue)
-		So(strings.Contains(string(resp.Body()), "less-layers-false"), ShouldBeFalse)
-		So(strings.Contains(string(resp.Body()), "more-layers"), ShouldBeFalse)
-		So(strings.Contains(string(resp.Body()), "diff-layers"), ShouldBeFalse)
-		So(strings.Contains(string(resp.Body()), "test-repo"), ShouldBeTrue) //nolint:goconst // should not list given image
-		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, 200)
-	})
+			resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
+			So(resp, ShouldNotBeNil)
+			So(strings.Contains(string(resp.Body()), "less-layers"), ShouldBeTrue)
+			So(strings.Contains(string(resp.Body()), "one-layer"), ShouldBeTrue)
+			So(strings.Contains(string(resp.Body()), "same-layers"), ShouldBeFalse) //nolint:goconst
+			So(strings.Contains(string(resp.Body()), "less-layers-false"), ShouldBeFalse)
+			So(strings.Contains(string(resp.Body()), "more-layers"), ShouldBeFalse)
+			So(strings.Contains(string(resp.Body()), "diff-layers"), ShouldBeFalse)
+			So(strings.Contains(string(resp.Body()), "test-repo"), ShouldBeFalse) //nolint:goconst // should not list given image
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, 200)
+		})
 
-	Convey("Nonexistent repository", t, func() {
-		query := `
-			{
-				BaseImageList(image:"nonexistent-image"){
-					RepoName,
-					Tag,
-					Digest,
-					ConfigDigest,
-					LastUpdated,
-					IsSigned,
-					Size
-				}
-			}`
+		Convey("paginated query", func() {
+			query := `
+				{
+					BaseImageList(image:"test-repo:latest", requestedPage:{limit: 1, offset: 0, sortBy:RELEVANCE}){
+						Results{
+							RepoName,
+							Tag,
+							Digest,
+							ConfigDigest,
+							LastUpdated,
+							IsSigned,
+							Size
+						}
+					}
+				}`
 
-		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
-		So(strings.Contains(string(resp.Body()), "repository: not found"), ShouldBeTrue)
-		So(err, ShouldBeNil)
-	})
-
-	Convey("Failed to get manifest", t, func() {
-		err := os.Mkdir(path.Join(rootDir, "fail-image"), 0o000)
-		So(err, ShouldBeNil)
-
-		query := `
-			{
-				BaseImageList(image:"fail-image"){
-					RepoName,
-					Tag,
-					Digest,
-					ConfigDigest,
-					LastUpdated,
-					IsSigned,
-					Size
-				}
-			}`
-
-		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
-		So(strings.Contains(string(resp.Body()), "permission denied"), ShouldBeTrue)
-		So(err, ShouldBeNil)
+			resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
+			So(resp, ShouldNotBeNil)
+			So(strings.Contains(string(resp.Body()), "less-layers"), ShouldBeTrue)
+			So(strings.Contains(string(resp.Body()), "one-layer"), ShouldBeFalse)
+			So(strings.Contains(string(resp.Body()), "same-layers"), ShouldBeFalse) //nolint:goconst
+			So(strings.Contains(string(resp.Body()), "less-layers-false"), ShouldBeFalse)
+			So(strings.Contains(string(resp.Body()), "more-layers"), ShouldBeFalse)
+			So(strings.Contains(string(resp.Body()), "diff-layers"), ShouldBeFalse)
+			So(strings.Contains(string(resp.Body()), "test-repo"), ShouldBeFalse) //nolint:goconst // should not list given image
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, 200)
+		})
 	})
 }
 
@@ -1944,18 +2050,20 @@ func TestBaseImageListNoRepos(t *testing.T) {
 		query := `
 			{
 				BaseImageList(image:"test-image"){
-					RepoName,
-					Tag,
-					Digest,
-					ConfigDigest,
-					LastUpdated,
-					IsSigned,
-					Size
+					Results{
+						RepoName,
+						Tag,
+						Digest,
+						ConfigDigest,
+						LastUpdated,
+						IsSigned,
+						Size
+					}
 				}
 			}`
 
 		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
-		So(strings.Contains(string(resp.Body()), "{\"data\":{\"BaseImageList\":[]}}"), ShouldBeTrue)
+		So(strings.Contains(string(resp.Body()), "{\"data\":{\"BaseImageList\":{\"Results\":[]}}}"), ShouldBeTrue)
 		So(err, ShouldBeNil)
 	})
 }

--- a/pkg/extensions/search/resolver.go
+++ b/pkg/extensions/search/resolver.go
@@ -121,7 +121,7 @@ func getImageListForDigest(ctx context.Context, digest string, repoDB repodb.Rep
 	}
 
 	// get all repos
-	reposMeta, manifestMetaMap, err := repoDB.FilterTags(ctx, FilterByDigest(digest), pageInput)
+	reposMeta, manifestMetaMap, _, err := repoDB.FilterTags(ctx, FilterByDigest(digest), pageInput)
 	if err != nil {
 		return []*gql_generated.ImageSummary{}, err
 	}
@@ -148,6 +148,12 @@ func getImageSummary(ctx context.Context, repo, tag string, repoDB repodb.RepoDB
 	manifestDigest, ok := repoMeta.Tags[tag]
 	if !ok {
 		return nil, gqlerror.Errorf("can't find image: %s:%s", repo, tag)
+	}
+
+	for t := range repoMeta.Tags {
+		if t != tag {
+			delete(repoMeta.Tags, t)
+		}
 	}
 
 	manifestMeta, err := repoDB.GetManifestMeta(godigest.Digest(manifestDigest))
@@ -288,7 +294,7 @@ func getImageListForCVE(
 	}
 
 	// get all repos
-	reposMeta, manifestMetaMap, err := repoDB.FilterTags(ctx, FilterByTagInfo(affectedImages), pageInput)
+	reposMeta, manifestMetaMap, _, err := repoDB.FilterTags(ctx, FilterByTagInfo(affectedImages), pageInput)
 	if err != nil {
 		return []*gql_generated.ImageSummary{}, err
 	}
@@ -340,7 +346,7 @@ func getImageListWithCVEFixed(
 	}
 
 	// get all repos
-	reposMeta, manifestMetaMap, err := repoDB.FilterTags(ctx, FilterByTagInfo(tagsInfo), pageInput)
+	reposMeta, manifestMetaMap, _, err := repoDB.FilterTags(ctx, FilterByTagInfo(tagsInfo), pageInput)
 	if err != nil {
 		return []*gql_generated.ImageSummary{}, err
 	}
@@ -492,6 +498,218 @@ func canSkipField(preloads map[string]bool, s string) bool {
 	fieldIsPresent := preloads[s]
 
 	return !fieldIsPresent
+}
+
+func derivedImageList(ctx context.Context, image string, repoDB repodb.RepoDB,
+	requestedPage *gql_generated.PageInput,
+	cveInfo cveinfo.CveInfo, log log.Logger,
+) (*gql_generated.PaginatedImagesResult, error) {
+	derivedList := make([]*gql_generated.ImageSummary, 0)
+
+	if requestedPage == nil {
+		requestedPage = &gql_generated.PageInput{}
+	}
+
+	pageInput := repodb.PageInput{
+		Limit:  safeDerefferencing(requestedPage.Limit, 0),
+		Offset: safeDerefferencing(requestedPage.Offset, 0),
+		SortBy: repodb.SortCriteria(
+			safeDerefferencing(requestedPage.SortBy, gql_generated.SortCriteriaUpdateTime),
+		),
+	}
+
+	skip := convert.SkipQGLField{
+		Vulnerabilities: canSkipField(convert.GetPreloads(ctx), "Vulnerabilities"),
+	}
+
+	imageRepo, imageTag := common.GetImageDirAndTag(image)
+
+	searchedImage, err := getImageSummary(ctx, imageRepo, imageTag, repoDB, cveInfo, log)
+	if err != nil {
+		if errors.Is(err, zerr.ErrRepoMetaNotFound) {
+			return &gql_generated.PaginatedImagesResult{}, nil
+		}
+
+		return &gql_generated.PaginatedImagesResult{}, err
+	}
+
+	// we need all available tags
+	reposMeta, manifestMetaMap, pageInfo, err := repoDB.FilterTags(ctx,
+		filterDerivedImages(searchedImage),
+		pageInput)
+	if err != nil {
+		return &gql_generated.PaginatedImagesResult{}, err
+	}
+
+	for _, repoMeta := range reposMeta {
+		summary := convert.RepoMeta2ImageSummaries(ctx, repoMeta, manifestMetaMap, skip, cveInfo)
+		derivedList = append(derivedList, summary...)
+	}
+
+	if len(derivedList) == 0 {
+		log.Info().Msg("no images found")
+
+		return &gql_generated.PaginatedImagesResult{
+			Page:    &gql_generated.PageInfo{},
+			Results: derivedList,
+		}, nil
+	}
+
+	return &gql_generated.PaginatedImagesResult{
+		Results: derivedList,
+		Page: &gql_generated.PageInfo{
+			TotalCount: pageInfo.TotalCount,
+			ItemCount:  pageInfo.ItemCount,
+		},
+	}, nil
+}
+
+func filterDerivedImages(image *gql_generated.ImageSummary) repodb.FilterFunc {
+	return func(repoMeta repodb.RepoMetadata, manifestMeta repodb.ManifestMetadata) bool {
+		var addImageToList bool
+
+		var imageManifest ispec.Manifest
+
+		err := json.Unmarshal(manifestMeta.ManifestBlob, &imageManifest)
+		if err != nil {
+			return false
+		}
+
+		manifestDigest := godigest.FromBytes(manifestMeta.ManifestBlob).String()
+		if manifestDigest == *image.Digest {
+			return false
+		}
+
+		imageLayers := image.Layers
+
+		addImageToList = false
+		layers := imageManifest.Layers
+
+		sameLayer := 0
+
+		for _, l := range imageLayers {
+			for _, k := range layers {
+				if k.Digest.String() == *l.Digest {
+					sameLayer++
+				}
+			}
+		}
+
+		// if all layers are the same
+		if sameLayer == len(imageLayers) {
+			// it's a derived image
+			addImageToList = true
+		}
+
+		return addImageToList
+	}
+}
+
+func baseImageList(ctx context.Context, image string, repoDB repodb.RepoDB,
+	requestedPage *gql_generated.PageInput,
+	cveInfo cveinfo.CveInfo, log log.Logger,
+) (*gql_generated.PaginatedImagesResult, error) {
+	imageSummaries := make([]*gql_generated.ImageSummary, 0)
+
+	if requestedPage == nil {
+		requestedPage = &gql_generated.PageInput{}
+	}
+
+	pageInput := repodb.PageInput{
+		Limit:  safeDerefferencing(requestedPage.Limit, 0),
+		Offset: safeDerefferencing(requestedPage.Offset, 0),
+		SortBy: repodb.SortCriteria(
+			safeDerefferencing(requestedPage.SortBy, gql_generated.SortCriteriaUpdateTime),
+		),
+	}
+
+	skip := convert.SkipQGLField{
+		Vulnerabilities: canSkipField(convert.GetPreloads(ctx), "Vulnerabilities"),
+	}
+
+	imageRepo, imageTag := common.GetImageDirAndTag(image)
+
+	searchedImage, err := getImageSummary(ctx, imageRepo, imageTag, repoDB, cveInfo, log)
+	if err != nil {
+		if errors.Is(err, zerr.ErrRepoMetaNotFound) {
+			return &gql_generated.PaginatedImagesResult{}, nil
+		}
+
+		return &gql_generated.PaginatedImagesResult{}, err
+	}
+
+	// we need all available tags
+	reposMeta, manifestMetaMap, pageInfo, err := repoDB.FilterTags(ctx,
+		filterBaseImages(searchedImage),
+		pageInput)
+	if err != nil {
+		return &gql_generated.PaginatedImagesResult{}, err
+	}
+
+	for _, repoMeta := range reposMeta {
+		summary := convert.RepoMeta2ImageSummaries(ctx, repoMeta, manifestMetaMap, skip, cveInfo)
+		imageSummaries = append(imageSummaries, summary...)
+	}
+
+	if len(imageSummaries) == 0 {
+		log.Info().Msg("no images found")
+
+		return &gql_generated.PaginatedImagesResult{
+			Results: imageSummaries,
+			Page:    &gql_generated.PageInfo{},
+		}, nil
+	}
+
+	return &gql_generated.PaginatedImagesResult{
+		Page: &gql_generated.PageInfo{
+			TotalCount: pageInfo.TotalCount,
+			ItemCount:  pageInfo.ItemCount,
+		},
+		Results: imageSummaries,
+	}, nil
+}
+
+func filterBaseImages(image *gql_generated.ImageSummary) repodb.FilterFunc {
+	return func(repoMeta repodb.RepoMetadata, manifestMeta repodb.ManifestMetadata) bool {
+		var addImageToList bool
+
+		var imageManifest ispec.Manifest
+
+		err := json.Unmarshal(manifestMeta.ManifestBlob, &imageManifest)
+		if err != nil {
+			return false
+		}
+
+		manifestDigest := godigest.FromBytes(manifestMeta.ManifestBlob).String()
+		if manifestDigest == *image.Digest {
+			return false
+		}
+
+		imageLayers := image.Layers
+
+		addImageToList = true
+		layers := imageManifest.Layers
+
+		for _, l := range layers {
+			foundLayer := false
+
+			for _, k := range imageLayers {
+				if l.Digest.String() == *k.Digest {
+					foundLayer = true
+
+					break
+				}
+			}
+
+			if !foundLayer {
+				addImageToList = false
+
+				break
+			}
+		}
+
+		return addImageToList
+	}
 }
 
 func validateGlobalSearchInput(query string, filter *gql_generated.Filter,
@@ -694,7 +912,7 @@ func getImageList(ctx context.Context, repo string, repoDB repodb.RepoDB, cveInf
 	}
 
 	// reposMeta, manifestMetaMap, err := repoDB.SearchRepos(ctx, repo, repodb.Filter{}, pageInput)
-	reposMeta, manifestMetaMap, err := repoDB.FilterTags(ctx,
+	reposMeta, manifestMetaMap, _, err := repoDB.FilterTags(ctx,
 		func(repoMeta repodb.RepoMetadata, manifestMeta repodb.ManifestMetadata) bool {
 			return true
 		},

--- a/pkg/extensions/search/resolver_test.go
+++ b/pkg/extensions/search/resolver_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	godigest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -617,8 +618,8 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
-					return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, ErrTestError
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+					return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, repodb.PageInfo{}, ErrTestError
 				},
 			}
 
@@ -632,7 +633,7 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					repos := []repodb.RepoMetadata{
 						{
 							Name: "test",
@@ -667,7 +668,7 @@ func TestImageListForDigest(t *testing.T) {
 						},
 					}
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -688,7 +689,7 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					repos := []repodb.RepoMetadata{
 						{
 							Name: "test",
@@ -729,7 +730,7 @@ func TestImageListForDigest(t *testing.T) {
 
 					repos[0].Tags = matchedTags
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -769,7 +770,7 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					repos := []repodb.RepoMetadata{
 						{
 							Name: "test",
@@ -815,7 +816,7 @@ func TestImageListForDigest(t *testing.T) {
 
 					repos[0].Tags = matchedTags
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -851,7 +852,7 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					repos := []repodb.RepoMetadata{
 						{
 							Name: "test",
@@ -899,7 +900,7 @@ func TestImageListForDigest(t *testing.T) {
 
 					repos[0].Tags = matchedTags
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -933,7 +934,7 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					repos := []repodb.RepoMetadata{
 						{
 							Name: "test",
@@ -976,7 +977,7 @@ func TestImageListForDigest(t *testing.T) {
 						repos[i].Tags = matchedTags
 					}
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -1010,10 +1011,10 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					pageFinder, err := repodb.NewBaseImagePageFinder(requestedPage.Limit, requestedPage.Offset, requestedPage.SortBy)
 					if err != nil {
-						return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, err
+						return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, repodb.PageInfo{}, err
 					}
 
 					repos := []repodb.RepoMetadata{
@@ -1064,7 +1065,7 @@ func TestImageListForDigest(t *testing.T) {
 
 					repos, _ = pageFinder.Page()
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -1095,8 +1096,8 @@ func TestImageList(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
-					return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, ErrTestError
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+					return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, repodb.PageInfo{}, ErrTestError
 				},
 			}
 
@@ -1111,7 +1112,7 @@ func TestImageList(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					repos := []repodb.RepoMetadata{
 						{
 							Name: "test",
@@ -1148,7 +1149,7 @@ func TestImageList(t *testing.T) {
 						},
 					}
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -2001,4 +2002,711 @@ func getPageInput(limit int, offset int) *gql_generated.PageInput {
 		Offset: &offset,
 		SortBy: &sortCriteria,
 	}
+}
+
+func TestDerivedImageList(t *testing.T) {
+	Convey("RepoDB FilterTags error", t, func() {
+		mockSearchDB := mocks.RepoDBMock{
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				return make([]repodb.RepoMetadata, 0), make(map[string]repodb.ManifestMetadata), repodb.PageInfo{}, ErrTestError
+			},
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{}, ErrTestError
+			},
+			GetManifestMetaFn: func(manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{}, ErrTestError
+			},
+		}
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+		images, err := derivedImageList(responseContext, "repo1:1.0.1", mockSearchDB, &gql_generated.PageInput{},
+			mockCve, log.NewLogger("debug", ""))
+		So(err, ShouldNotBeNil)
+		So(images.Results, ShouldBeEmpty)
+	})
+
+	//nolint: dupl
+	Convey("RepoDB FilterTags no repo available", t, func() {
+		configBlob, err := json.Marshal(ispec.Image{
+			Config: ispec.ImageConfig{
+				Labels: map[string]string{},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		manifest := ispec.Manifest{}
+
+		manifestBlob, err := json.Marshal(manifest)
+		So(err, ShouldBeNil)
+
+		manifestDigest := godigest.FromBytes(manifestBlob)
+
+		mockSearchDB := mocks.RepoDBMock{
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				return make([]repodb.RepoMetadata, 0), make(map[string]repodb.ManifestMetadata), repodb.PageInfo{}, nil
+			},
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{
+					Name: "repo1",
+					Tags: map[string]string{
+						"1.0.1": manifestDigest.String(),
+					},
+				}, nil
+			},
+			GetManifestMetaFn: func(manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{
+					ManifestBlob: manifestBlob,
+					ConfigBlob:   configBlob,
+				}, nil
+			},
+		}
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+		images, err := derivedImageList(responseContext, "repo1:1.0.1", mockSearchDB, &gql_generated.PageInput{},
+			mockCve, log.NewLogger("debug", ""))
+		So(err, ShouldBeNil)
+		So(images.Results, ShouldBeEmpty)
+	})
+
+	//nolint: dupl
+	Convey("derived image list working", t, func() {
+		configBlob, err := json.Marshal(ispec.Image{
+			Config: ispec.ImageConfig{
+				Labels: map[string]string{},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		configDigest := godigest.FromBytes(configBlob)
+
+		layers := [][]byte{
+			{10, 11, 10, 11},
+			{11, 11, 11, 11},
+			{10, 10, 10, 11},
+			{13, 14, 15, 11},
+		}
+
+		manifestBlob, err := json.Marshal(ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[2]),
+					Size:      int64(len(layers[2])),
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		derivedManifestBlob, err := json.Marshal(ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[2]),
+					Size:      int64(len(layers[2])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[3]),
+					Size:      int64(len(layers[3])),
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		manifestMetas := map[string]repodb.ManifestMetadata{
+			"digestTag1.0.1": {
+				ManifestBlob:  manifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(map[string][]string),
+				Dependencies:  make([]string, 0),
+				Dependants:    make([]string, 0),
+				BlobsSize:     0,
+				BlobCount:     0,
+			},
+			"digestTag1.0.2": {
+				ManifestBlob:  derivedManifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(map[string][]string),
+				Dependencies:  make([]string, 0),
+				Dependants:    make([]string, 0),
+				BlobsSize:     0,
+				BlobCount:     0,
+			},
+			"digestTag1.0.3": {
+				ManifestBlob:  derivedManifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(map[string][]string),
+				Dependencies:  make([]string, 0),
+				Dependants:    make([]string, 0),
+				BlobsSize:     0,
+				BlobCount:     0,
+			},
+		}
+		manifestDigest := godigest.FromBytes(manifestBlob)
+
+		mockSearchDB := mocks.RepoDBMock{
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{
+					Name: "repo1",
+					Tags: map[string]string{
+						"1.0.1": manifestDigest.String(),
+					},
+				}, nil
+			},
+			GetManifestMetaFn: func(manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{
+					ManifestBlob: manifestBlob,
+					ConfigBlob:   configBlob,
+				}, nil
+			},
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				pageFinder, err := repodb.NewBaseImagePageFinder(requestedPage.Limit, requestedPage.Offset, requestedPage.SortBy)
+				So(err, ShouldBeNil)
+
+				repos := []repodb.RepoMetadata{
+					{
+						Name: "repo1",
+						Tags: map[string]string{
+							"1.0.1": "digestTag1.0.1",
+							"1.0.2": "digestTag1.0.2",
+							"1.0.3": "digestTag1.0.3",
+						},
+						Signatures:  []string{"testSignature"},
+						Stars:       100,
+						Description: "Description repo1",
+						LogoPath:    "test/logoPath",
+					},
+				}
+
+				for i, repo := range repos {
+					matchedTags := repo.Tags
+
+					for tag, manifestDigest := range repo.Tags {
+						if !filter(repo, manifestMetas[manifestDigest]) {
+							delete(matchedTags, tag)
+							delete(manifestMetas, manifestDigest)
+
+							continue
+						}
+					}
+
+					repos[i].Tags = matchedTags
+
+					pageFinder.Add(repodb.DetailedRepoMeta{
+						RepoMeta: repo,
+					})
+				}
+				repos, pageInfo := pageFinder.Page()
+
+				return repos, manifestMetas, pageInfo, nil
+			},
+		}
+
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+
+		Convey("valid derivedImageList, results not affected by pageInput", func() {
+			images, err := derivedImageList(responseContext, "repo1:1.0.1", mockSearchDB, &gql_generated.PageInput{},
+				mockCve, log.NewLogger("debug", ""))
+			So(err, ShouldBeNil)
+			So(images.Results, ShouldNotBeEmpty)
+			So(len(images.Results), ShouldEqual, 2)
+		})
+
+		Convey("valid derivedImageList, results affected by pageInput", func() {
+			limit := 1
+			offset := 0
+			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
+			pageInput := gql_generated.PageInput{
+				Limit:  &limit,
+				Offset: &offset,
+				SortBy: &sortCriteria,
+			}
+
+			images, err := derivedImageList(responseContext, "repo1:1.0.1", mockSearchDB, &pageInput,
+				mockCve, log.NewLogger("debug", ""))
+			So(err, ShouldBeNil)
+			So(images.Results, ShouldNotBeEmpty)
+			So(len(images.Results), ShouldEqual, limit)
+		})
+	})
+}
+
+func TestBaseImageList(t *testing.T) {
+	Convey("RepoDB FilterTags error", t, func() {
+		mockSearchDB := mocks.RepoDBMock{
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				return make([]repodb.RepoMetadata, 0), make(map[string]repodb.ManifestMetadata), repodb.PageInfo{}, ErrTestError
+			},
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{}, ErrTestError
+			},
+			GetManifestMetaFn: func(manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{}, ErrTestError
+			},
+		}
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+		images, err := baseImageList(responseContext, "repo1:1.0.2", mockSearchDB, &gql_generated.PageInput{},
+			mockCve, log.NewLogger("debug", ""))
+		So(err, ShouldNotBeNil)
+		So(images.Results, ShouldBeEmpty)
+	})
+
+	//nolint: dupl
+	Convey("RepoDB FilterTags no repo available", t, func() {
+		configBlob, err := json.Marshal(ispec.Image{
+			Config: ispec.ImageConfig{
+				Labels: map[string]string{},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		manifest := ispec.Manifest{}
+
+		manifestBlob, err := json.Marshal(manifest)
+		So(err, ShouldBeNil)
+
+		manifestDigest := godigest.FromBytes(manifestBlob)
+
+		mockSearchDB := mocks.RepoDBMock{
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				return make([]repodb.RepoMetadata, 0), make(map[string]repodb.ManifestMetadata), repodb.PageInfo{}, nil
+			},
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{
+					Name: "repo1",
+					Tags: map[string]string{
+						"1.0.2": manifestDigest.String(),
+					},
+				}, nil
+			},
+			GetManifestMetaFn: func(manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{
+					ManifestBlob: manifestBlob,
+					ConfigBlob:   configBlob,
+				}, nil
+			},
+		}
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+		images, err := baseImageList(responseContext, "repo1:1.0.2", mockSearchDB, &gql_generated.PageInput{},
+			mockCve, log.NewLogger("debug", ""))
+		So(err, ShouldBeNil)
+		So(images.Results, ShouldBeEmpty)
+	})
+
+	//nolint: dupl
+	Convey("base image list working", t, func() {
+		configBlob, err := json.Marshal(ispec.Image{
+			Config: ispec.ImageConfig{
+				Labels: map[string]string{},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		configDigest := godigest.FromBytes(configBlob)
+
+		layers := [][]byte{
+			{10, 11, 10, 11},
+			{11, 11, 11, 11},
+			{10, 10, 10, 11},
+			{13, 14, 15, 11},
+		}
+
+		manifestBlob, err := json.Marshal(ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[2]),
+					Size:      int64(len(layers[2])),
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		derivedManifestBlob, err := json.Marshal(ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[2]),
+					Size:      int64(len(layers[2])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[3]),
+					Size:      int64(len(layers[3])),
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		manifestMetas := map[string]repodb.ManifestMetadata{
+			"digestTag1.0.1": {
+				ManifestBlob:  manifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(map[string][]string),
+				Dependencies:  make([]string, 0),
+				Dependants:    make([]string, 0),
+				BlobsSize:     0,
+				BlobCount:     0,
+			},
+			"digestTag1.0.2": {
+				ManifestBlob:  derivedManifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(map[string][]string),
+				Dependencies:  make([]string, 0),
+				Dependants:    make([]string, 0),
+				BlobsSize:     0,
+				BlobCount:     0,
+			},
+		}
+		derivedManifestDigest := godigest.FromBytes(derivedManifestBlob)
+
+		mockSearchDB := mocks.RepoDBMock{
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{
+					Name: "repo1",
+					Tags: map[string]string{
+						"1.0.2": derivedManifestDigest.String(),
+					},
+				}, nil
+			},
+			GetManifestMetaFn: func(manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{
+					ManifestBlob: derivedManifestBlob,
+					ConfigBlob:   configBlob,
+				}, nil
+			},
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				pageFinder, err := repodb.NewBaseImagePageFinder(requestedPage.Limit, requestedPage.Offset, requestedPage.SortBy)
+				So(err, ShouldBeNil)
+
+				repos := []repodb.RepoMetadata{
+					{
+						Name: "repo1",
+						Tags: map[string]string{
+							"1.0.1": "digestTag1.0.1",
+							"1.0.3": "digestTag1.0.1",
+							"1.0.2": "digestTag1.0.2",
+						},
+						Signatures:  []string{"testSignature"},
+						Stars:       100,
+						Description: "Description repo1",
+						LogoPath:    "test/logoPath",
+					},
+				}
+
+				for i, repo := range repos {
+					matchedTags := repo.Tags
+
+					for tag, manifestDigest := range repo.Tags {
+						if !filter(repo, manifestMetas[manifestDigest]) {
+							delete(matchedTags, tag)
+							delete(manifestMetas, manifestDigest)
+
+							continue
+						}
+					}
+
+					repos[i].Tags = matchedTags
+
+					pageFinder.Add(repodb.DetailedRepoMeta{
+						RepoMeta: repo,
+					})
+				}
+
+				repos, pageInfo := pageFinder.Page()
+
+				return repos, manifestMetas, pageInfo, nil
+			},
+		}
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+
+		Convey("valid baseImageList, results not affected by pageInput", func() {
+			images, err := baseImageList(responseContext, "repo1:1.0.2", mockSearchDB,
+				&gql_generated.PageInput{}, mockCve, log.NewLogger("debug", ""))
+			So(err, ShouldBeNil)
+			So(images.Results, ShouldNotBeEmpty)
+			So(len(images.Results), ShouldEqual, 2)
+			So(*images.Results[0].Tag, ShouldEqual, "1.0.1")
+		})
+
+		Convey("valid baseImageList, results affected by pageInput", func() {
+			limit := 1
+			offset := 0
+			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
+			pageInput := gql_generated.PageInput{
+				Limit:  &limit,
+				Offset: &offset,
+				SortBy: &sortCriteria,
+			}
+
+			images, err := baseImageList(responseContext, "repo1:1.0.2", mockSearchDB,
+				&pageInput, mockCve, log.NewLogger("debug", ""))
+			So(err, ShouldBeNil)
+			So(images.Results, ShouldNotBeEmpty)
+			So(len(images.Results), ShouldEqual, limit)
+			So(*images.Results[0].Tag, ShouldEqual, "1.0.1")
+		})
+	})
+
+	//nolint: dupl
+	Convey("filterTags working, no base image list found", t, func() {
+		configBlob, err := json.Marshal(ispec.Image{
+			Config: ispec.ImageConfig{
+				Labels: map[string]string{},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		configDigest := godigest.FromBytes(configBlob)
+
+		layers := [][]byte{
+			{10, 11, 10, 11},
+			{11, 11, 11, 11},
+			{10, 10, 10, 11},
+			{13, 14, 15, 11},
+		}
+
+		manifestBlob, err := json.Marshal(ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[2]),
+					Size:      int64(len(layers[2])),
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		derivedManifestBlob, err := json.Marshal(ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[3]),
+					Size:      int64(len(layers[3])),
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		manifestMetas := map[string]repodb.ManifestMetadata{
+			"digestTag1.0.1": {
+				ManifestBlob:  manifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(map[string][]string),
+				Dependencies:  make([]string, 0),
+				Dependants:    make([]string, 0),
+				BlobsSize:     0,
+				BlobCount:     0,
+			},
+			"digestTag1.0.2": {
+				ManifestBlob:  derivedManifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(map[string][]string),
+				Dependencies:  make([]string, 0),
+				Dependants:    make([]string, 0),
+				BlobsSize:     0,
+				BlobCount:     0,
+			},
+		}
+		derivedManifestDigest := godigest.FromBytes(derivedManifestBlob)
+
+		mockSearchDB := mocks.RepoDBMock{
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{
+					Name: "repo1",
+					Tags: map[string]string{
+						"1.0.2": derivedManifestDigest.String(),
+					},
+				}, nil
+			},
+			GetManifestMetaFn: func(manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{
+					ManifestBlob: derivedManifestBlob,
+					ConfigBlob:   configBlob,
+				}, nil
+			},
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				pageFinder, err := repodb.NewBaseImagePageFinder(requestedPage.Limit, requestedPage.Offset, requestedPage.SortBy)
+				So(err, ShouldBeNil)
+
+				repos := []repodb.RepoMetadata{
+					{
+						Name: "repo1",
+						Tags: map[string]string{
+							"1.0.1": "digestTag1.0.1",
+							"1.0.2": "digestTag1.0.2",
+						},
+						Signatures:  []string{"testSignature"},
+						Stars:       100,
+						Description: "Description repo1",
+						LogoPath:    "test/logoPath",
+					},
+				}
+
+				for i, repo := range repos {
+					matchedTags := repo.Tags
+
+					for tag, manifestDigest := range repo.Tags {
+						if !filter(repo, manifestMetas[manifestDigest]) {
+							delete(matchedTags, tag)
+							delete(manifestMetas, manifestDigest)
+
+							continue
+						}
+					}
+
+					repos[i].Tags = matchedTags
+
+					pageFinder.Add(repodb.DetailedRepoMeta{
+						RepoMeta: repo,
+					})
+				}
+
+				return repos, manifestMetas, repodb.PageInfo{}, nil
+			},
+		}
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+		images, err := baseImageList(responseContext, "repo1:1.0.2", mockSearchDB, &gql_generated.PageInput{},
+			mockCve, log.NewLogger("debug", ""))
+		So(err, ShouldBeNil)
+		So(images.Results, ShouldBeEmpty)
+	})
 }

--- a/pkg/extensions/search/schema.graphql
+++ b/pkg/extensions/search/schema.graphql
@@ -230,12 +230,12 @@ type Query {
     """
     List of images which use the argument image
     """
-    DerivedImageList(image: String!): [ImageSummary!]
+    DerivedImageList(image: String!, requestedPage: PageInput): PaginatedImagesResult!
 
     """
     List of images on which the argument image depends on
     """
-    BaseImageList(image: String!): [ImageSummary!]
+    BaseImageList(image: String!, requestedPage: PageInput): PaginatedImagesResult!
 
     """
     Search for a specific image using its name

--- a/pkg/extensions/search/schema.resolvers.go
+++ b/pkg/extensions/search/schema.resolvers.go
@@ -87,149 +87,17 @@ func (r *queryResolver) GlobalSearch(ctx context.Context, query string, filter *
 }
 
 // DependencyListForImage is the resolver for the DependencyListForImage field.
-func (r *queryResolver) DerivedImageList(ctx context.Context, image string) ([]*gql_generated.ImageSummary, error) {
-	layoutUtils := common.NewBaseOciLayoutUtils(r.storeController, r.log)
-	imageList := make([]*gql_generated.ImageSummary, 0)
+func (r *queryResolver) DerivedImageList(ctx context.Context, image string, requestedPage *gql_generated.PageInput) (*gql_generated.PaginatedImagesResult, error) {
+	derivedList, err := derivedImageList(ctx, image, r.repoDB, requestedPage, r.cveInfo, r.log)
 
-	repoList, err := layoutUtils.GetRepositories()
-	if err != nil {
-		r.log.Error().Err(err).Msg("unable to get repositories list")
-
-		return nil, err
-	}
-
-	if len(repoList) == 0 {
-		r.log.Info().Msg("no repositories found")
-
-		return imageList, nil
-	}
-
-	imageDir, imageTag := common.GetImageDirAndTag(image)
-
-	imageManifest, _, err := layoutUtils.GetImageManifest(imageDir, imageTag)
-	if err != nil {
-		r.log.Info().Str("image", image).Msg("image not found")
-
-		return imageList, err
-	}
-
-	imageLayers := imageManifest.Layers
-
-	for _, repo := range repoList {
-		repoInfo, err := r.ExpandedRepoInfo(ctx, repo)
-		if err != nil {
-			r.log.Error().Err(err).Msg("unable to get image list")
-
-			return nil, err
-		}
-
-		imageSummaries := repoInfo.Images
-
-		// verify every image
-		for _, imageSummary := range imageSummaries {
-			if imageTag == *imageSummary.Tag && imageDir == repo {
-				continue
-			}
-
-			layers := imageSummary.Layers
-
-			sameLayer := 0
-
-			for _, l := range imageLayers {
-				for _, k := range layers {
-					if *k.Digest == l.Digest.String() {
-						sameLayer++
-					}
-				}
-			}
-
-			// if all layers are the same
-			if sameLayer == len(imageLayers) {
-				// add to returned list
-				imageList = append(imageList, imageSummary)
-			}
-		}
-	}
-
-	return imageList, nil
+	return derivedList, err
 }
 
 // BaseImageList is the resolver for the BaseImageList field.
-func (r *queryResolver) BaseImageList(ctx context.Context, image string) ([]*gql_generated.ImageSummary, error) {
-	layoutUtils := common.NewBaseOciLayoutUtils(r.storeController, r.log)
-	imageList := make([]*gql_generated.ImageSummary, 0)
+func (r *queryResolver) BaseImageList(ctx context.Context, image string, requestedPage *gql_generated.PageInput) (*gql_generated.PaginatedImagesResult, error) {
+	imageList, err := baseImageList(ctx, image, r.repoDB, requestedPage, r.cveInfo, r.log)
 
-	repoList, err := layoutUtils.GetRepositories()
-	if err != nil {
-		r.log.Error().Err(err).Msg("unable to get repositories list")
-
-		return nil, err
-	}
-
-	if len(repoList) == 0 {
-		r.log.Info().Msg("no repositories found")
-
-		return imageList, nil
-	}
-
-	imageDir, imageTag := common.GetImageDirAndTag(image)
-
-	imageManifest, _, err := layoutUtils.GetImageManifest(imageDir, imageTag)
-	if err != nil {
-		r.log.Info().Str("image", image).Msg("image not found")
-
-		return imageList, err
-	}
-
-	imageLayers := imageManifest.Layers
-
-	// This logic may not scale well in the future as we need to read all the
-	// manifest files from the disk when the call is made, we should improve in a future PR
-	for _, repo := range repoList {
-		repoInfo, err := r.ExpandedRepoInfo(ctx, repo)
-		if err != nil {
-			r.log.Error().Err(err).Msg("unable to get image list")
-
-			return nil, err
-		}
-
-		imageSummaries := repoInfo.Images
-
-		var addImageToList bool
-		// verify every image
-		for _, imageSummary := range imageSummaries {
-			if imageTag == *imageSummary.Tag && imageDir == repo {
-				continue
-			}
-
-			addImageToList = true
-			layers := imageSummary.Layers
-
-			for _, l := range layers {
-				foundLayer := false
-
-				for _, k := range imageLayers {
-					if *l.Digest == k.Digest.String() {
-						foundLayer = true
-
-						break
-					}
-				}
-
-				if !foundLayer {
-					addImageToList = false
-
-					break
-				}
-			}
-
-			if addImageToList {
-				imageList = append(imageList, imageSummary)
-			}
-		}
-	}
-
-	return imageList, nil
+	return imageList, err
 }
 
 // Image is the resolver for the Image field.

--- a/pkg/meta/repodb/boltdb_wrapper.go
+++ b/pkg/meta/repodb/boltdb_wrapper.go
@@ -711,16 +711,17 @@ func ScoreRepoName(searchText string, repoName string) int {
 
 func (bdw BoltDBWrapper) FilterTags(ctx context.Context, filter FilterFunc,
 	requestedPage PageInput,
-) ([]RepoMetadata, map[string]ManifestMetadata, error) {
+) ([]RepoMetadata, map[string]ManifestMetadata, PageInfo, error) {
 	var (
 		foundRepos               = make([]RepoMetadata, 0)
 		foundManifestMetadataMap = make(map[string]ManifestMetadata)
 		pageFinder               *ImagePageFinder
+		pageInfo                 PageInfo
 	)
 
 	pageFinder, err := NewBaseImagePageFinder(requestedPage.Limit, requestedPage.Offset, requestedPage.SortBy)
 	if err != nil {
-		return []RepoMetadata{}, map[string]ManifestMetadata{}, err
+		return []RepoMetadata{}, map[string]ManifestMetadata{}, PageInfo{}, err
 	}
 
 	err = bdw.db.View(func(tx *bolt.Tx) error {
@@ -793,7 +794,7 @@ func (bdw BoltDBWrapper) FilterTags(ctx context.Context, filter FilterFunc,
 			})
 		}
 
-		foundRepos, _ = pageFinder.Page()
+		foundRepos, pageInfo = pageFinder.Page()
 
 		// keep just the manifestMeta we need
 		for _, repoMeta := range foundRepos {
@@ -805,7 +806,7 @@ func (bdw BoltDBWrapper) FilterTags(ctx context.Context, filter FilterFunc,
 		return nil
 	})
 
-	return foundRepos, foundManifestMetadataMap, err
+	return foundRepos, foundManifestMetadataMap, pageInfo, err
 }
 
 func (bdw BoltDBWrapper) SearchTags(ctx context.Context, searchText string, filter Filter, requestedPage PageInput,

--- a/pkg/meta/repodb/repodb.go
+++ b/pkg/meta/repodb/repodb.go
@@ -70,7 +70,7 @@ type RepoDB interface { //nolint:interfacebloat
 
 	// FilterTags filters for images given a filter function
 	FilterTags(ctx context.Context, filter FilterFunc,
-		requestedPage PageInput) ([]RepoMetadata, map[string]ManifestMetadata, error)
+		requestedPage PageInput) ([]RepoMetadata, map[string]ManifestMetadata, PageInfo, error)
 
 	// SearchDigests searches for digests given a search string
 	SearchDigests(ctx context.Context, searchText string, requestedPage PageInput) (

--- a/pkg/test/mocks/repo_db_mock.go
+++ b/pkg/test/mocks/repo_db_mock.go
@@ -46,7 +46,7 @@ type RepoDBMock struct {
 
 	FilterTagsFn func(ctx context.Context, filter repodb.FilterFunc,
 		requestedPage repodb.PageInput,
-	) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error)
+	) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error)
 
 	SearchDigestsFn func(ctx context.Context, searchText string, requestedPage repodb.PageInput) (
 		[]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error)
@@ -197,12 +197,12 @@ func (sdm RepoDBMock) SearchTags(ctx context.Context, searchText string, filter 
 
 func (sdm RepoDBMock) FilterTags(ctx context.Context, filter repodb.FilterFunc,
 	requestedPage repodb.PageInput,
-) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 	if sdm.FilterTagsFn != nil {
 		return sdm.FilterTagsFn(ctx, filter, requestedPage)
 	}
 
-	return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, nil
+	return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, repodb.PageInfo{}, nil
 }
 
 func (sdm RepoDBMock) SearchDigests(ctx context.Context, searchText string, requestedPage repodb.PageInput,


### PR DESCRIPTION
- derivedImageList and baseImageList now use FilterTags to obtain results, each with its own filter function
- images that have the exact same manifest as the one provided as a parameter are no longer considered base images or derived images
- both calls can be made with specific pagination parameters, and the response will include PageInfo

Signed-off-by: Alex Stan <alexandrustan96@yahoo.ro>